### PR TITLE
Change bits order and fix initialize with custom field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bitarray (1.0.0)
+    bitarray (2.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -18,4 +18,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.13.7
+   1.16.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bitarray (2.0.0)
+    bitarray (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -47,8 +47,23 @@ ba.total_set
 #=> 7
 ```
 
+Initializing `BitArray` with a custom field value:
+
+```ruby
+ba = BitArray.new(16, ["0000111111110000"].pack('B*'))
+ba.to_s # "1111000000001111"
+```
+
+`BitArray` by default stores the bits in reverse order for each byte. If for example, you are initializing `BitArray` with Redis raw value manipulated with `setbit` / `getbit` operations, you will need to tell `BitArray` to not reverse the bits in each byte using the `reverse_byte: false` option:
+
+```ruby
+ba = BitArray.new(16, ["0000111111110000"].pack('B*'), reverse_byte: false)
+ba.to_s # "0000111111110000"
+```
+
+
 ## History
-- 2.0.0 in 2018 (Changed bits order to be compliant with Redis' setbit/getbit)
+- 1.2 in 2018 (Added option to skip reverse the bits for each byte)
 - 1.1 in 2018 (fixed a significant bug)
 - 1.0 in 2017 (updated for modern Ruby, more efficient storage, and 10th birthday)
 - 0.0.1 in 2012 (original v5 released on GitHub)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ba.total_set
 ```
 
 ## History
-- 1.0.1 in 2018 (Changed bits order to be compliant with Redis' setbit/getbit and fixed initialize with custom field)
+- 2.0.0 in 2018 (Changed bits order to be compliant with Redis' setbit/getbit and fixed initialize with custom field)
 - 1.0.0 in 2017 (updated for modern Ruby, more efficient storage, and 10th birthday)
 - 0.0.1 in 2012 (original v5 released on GitHub)
 - v5 (added support for flags being on by default, instead of off)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ ba.total_set
 ```
 
 ## History
-- 1.0 in 2017 (updated for modern Ruby, more efficient storage, and 10th birthday)
+- 1.0.1 in 2018 (Changed bits order to be compliant with Redis' setbit/getbit and fixed initialize with custom field)
+- 1.0.0 in 2017 (updated for modern Ruby, more efficient storage, and 10th birthday)
 - 0.0.1 in 2012 (original v5 released on GitHub)
 - v5 (added support for flags being on by default, instead of off)
 - v4 (fixed bug where setting 0 bits to 0 caused a set to 1)

--- a/lib/bitarray-array.rb
+++ b/lib/bitarray-array.rb
@@ -3,7 +3,7 @@ class BitArray
   attr_reader :field
   include Enumerable
 
-  VERSION = "2.0.0"
+  VERSION = "1.2.0"
   ELEMENT_WIDTH = 32
 
   def initialize(size, field = nil)

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -7,7 +7,7 @@ class BitArray
 
   def initialize(size, field = nil)
     @size = size
-    @field = "\0" * (size / 8 + 1)
+    @field = field || "\0" * (size / 8 + 1)
   end
 
   # Set a bit (1/0)

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -3,7 +3,7 @@ class BitArray
   attr_reader :field
   include Enumerable
 
-  VERSION = "1.1.0"
+  VERSION = "2.0.0"
 
   def initialize(size, field = nil)
     @size = size

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -13,15 +13,15 @@ class BitArray
   # Set a bit (1/0)
   def []=(position, value)
     if value == 1
-      @field.setbyte(position >> 3, @field.getbyte(position >> 3) | (1 << (position % 8)))
+      @field.setbyte(position >> 3, @field.getbyte(position >> 3) | (1 << (7 - position % 8)))
     else
-      @field.setbyte(position >> 3, @field.getbyte(position >> 3) ^ (1 << (position % 8)))
+      @field.setbyte(position >> 3, @field.getbyte(position >> 3) ^ (1 << (7 - position % 8)))
     end
   end
 
   # Read a bit (1/0)
   def [](position)
-    (@field.getbyte(position >> 3) & (1 << (position % 8))) > 0 ? 1 : 0
+    (@field.getbyte(position >> 3) & (1 << (7 - position % 8))) > 0 ? 1 : 0
   end
 
   # Iterate over each bit
@@ -31,7 +31,7 @@ class BitArray
 
   # Returns the field as a string like "0101010100111100," etc.
   def to_s
-    @field.bytes.collect{|ea| ("%08b" % ea).reverse}.join[0, @size]
+    @field.bytes.collect { |ea| ("%08b" % ea) }.join[0, @size]
   end
 
   # Returns the total number of bits that are set

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -3,7 +3,7 @@ class BitArray
   attr_reader :field
   include Enumerable
 
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 
   def initialize(size, field = nil)
     @size = size

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -3,25 +3,26 @@ class BitArray
   attr_reader :field
   include Enumerable
 
-  VERSION = "2.0.0"
+  VERSION = "1.2.0"
 
-  def initialize(size, field = nil)
+  def initialize(size, field = nil, reverse_byte: true)
     @size = size
     @field = field || "\0" * (size / 8 + 1)
+    @reverse_byte = reverse_byte
   end
 
   # Set a bit (1/0)
   def []=(position, value)
     if value == 1
-      @field.setbyte(position >> 3, @field.getbyte(position >> 3) | (1 << (7 - position % 8)))
+      @field.setbyte(position >> 3, @field.getbyte(position >> 3) | (1 << (byte_position(position) % 8)))
     else
-      @field.setbyte(position >> 3, @field.getbyte(position >> 3) & ~(1 << (7 - position % 8)))
+      @field.setbyte(position >> 3, @field.getbyte(position >> 3) & ~(1 << (byte_position(position) % 8)))
     end
   end
 
   # Read a bit (1/0)
   def [](position)
-    (@field.getbyte(position >> 3) & (1 << (7 - position % 8))) > 0 ? 1 : 0
+    (@field.getbyte(position >> 3) & (1 << (byte_position(position) % 8))) > 0 ? 1 : 0
   end
 
   # Iterate over each bit
@@ -31,12 +32,20 @@ class BitArray
 
   # Returns the field as a string like "0101010100111100," etc.
   def to_s
-    @field.bytes.collect { |ea| ("%08b" % ea) }.join[0, @size]
+    if @reverse_byte
+      @field.bytes.collect { |ea| ("%08b" % ea).reverse }.join[0, @size]
+    else
+      @field.bytes.collect { |ea| ("%08b" % ea) }.join[0, @size]
+    end
   end
 
   # Returns the total number of bits that are set
   # (The technique used here is about 6 times faster than using each or inject direct on the bitfield)
   def total_set
     @field.bytes.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
+  end
+
+  def byte_position(position)
+    @reverse_byte ? position : 7 - position
   end
 end

--- a/test/test_bitarray.rb
+++ b/test/test_bitarray.rb
@@ -52,6 +52,12 @@ class TestBitArray < Minitest::Test
     assert_equal "01000111001000001000000000000000010", ba.to_s
   end
 
+  def test_field
+    ba = BitArray.new(35)
+    [1, 5, 6, 7, 10, 16, 33].each{|i|ba[i] = 1}
+    assert_equal "0100011100100000100000000000000001000000", ba.field.unpack('B*')[0]
+  end
+
   def test_total_set
     ba = BitArray.new(10)
     ba[1] = 1

--- a/test/test_bitarray.rb
+++ b/test/test_bitarray.rb
@@ -48,14 +48,24 @@ class TestBitArray < Minitest::Test
 
   def test_to_s
     ba = BitArray.new(35)
-    [1, 5, 6, 7, 10, 16, 33].each{|i|ba[i] = 1}
+    [1, 5, 6, 7, 10, 16, 33].each { |i| ba[i] = 1}
     assert_equal "01000111001000001000000000000000010", ba.to_s
   end
 
   def test_field
     ba = BitArray.new(35)
-    [1, 5, 6, 7, 10, 16, 33].each{|i|ba[i] = 1}
+    [1, 5, 6, 7, 10, 16, 33].each { |i| ba[i] = 1}
     assert_equal "0100011100100000100000000000000001000000", ba.field.unpack('B*')[0]
+  end
+
+  def test_initialize_with_field
+    ba = BitArray.new(15, ["0100011100100001"].pack('B*'))
+
+    assert_equal [1, 5, 6, 7, 10, 15], 0.upto(15).select { |i| ba[i] == 1 }
+
+    ba[2] = 1
+    ba[12] = 1
+    assert_equal [1, 2, 5, 6, 7, 10, 12, 15], 0.upto(15).select { |i| ba[i] == 1 }
   end
 
   def test_total_set

--- a/test/test_bitarray.rb
+++ b/test/test_bitarray.rb
@@ -59,17 +59,17 @@ class TestBitArray < Minitest::Test
   def test_field
     ba = BitArray.new(35)
     [1, 5, 6, 7, 10, 16, 33].each { |i| ba[i] = 1}
-    assert_equal "0100011100100000100000000000000001000000", ba.field.unpack('B*')[0]
+    assert_equal "1110001000000100000000010000000000000010", ba.field.unpack('B*')[0]
   end
 
   def test_initialize_with_field
     ba = BitArray.new(15, ["0100011100100001"].pack('B*'))
 
-    assert_equal [1, 5, 6, 7, 10, 15], 0.upto(15).select { |i| ba[i] == 1 }
+    assert_equal [0, 1, 2, 6, 8, 13], 0.upto(15).select { |i| ba[i] == 1 }
 
     ba[2] = 1
     ba[12] = 1
-    assert_equal [1, 2, 5, 6, 7, 10, 12, 15], 0.upto(15).select { |i| ba[i] == 1 }
+    assert_equal [0, 1, 2, 6, 8, 12, 13], 0.upto(15).select { |i| ba[i] == 1 }
   end
 
   def test_total_set
@@ -78,5 +78,29 @@ class TestBitArray < Minitest::Test
     ba[5] = 1
     ba[9] = 1
     assert_equal 3, ba.total_set
+  end
+end
+
+class TestBitArrayWhenNonReversedByte < Minitest::Test
+  def test_to_s
+    ba = BitArray.new(35, nil, reverse_byte: true)
+    [1, 5, 6, 7, 10, 16, 33].each { |i| ba[i] = 1}
+    assert_equal "01000111001000001000000000000000010", ba.to_s
+  end
+
+  def test_field
+    ba = BitArray.new(35, nil, reverse_byte: false)
+    [1, 5, 6, 7, 10, 16, 33].each { |i| ba[i] = 1}
+    assert_equal "0100011100100000100000000000000001000000", ba.field.unpack('B*')[0]
+  end
+
+  def test_initialize_with_field
+    ba = BitArray.new(15, ["0100011100100001"].pack('B*'), reverse_byte: false)
+
+    assert_equal [1, 5, 6, 7, 10, 15], 0.upto(15).select { |i| ba[i] == 1 }
+
+    ba[2] = 1
+    ba[12] = 1
+    assert_equal [1, 2, 5, 6, 7, 10, 12, 15], 0.upto(15).select { |i| ba[i] == 1 }
   end
 end


### PR DESCRIPTION
Hi @peterc ,

Would you accept a non backward compatible change for the order of the bits so that it's compliant with Redis bit operations (setbit/getbit)? Alternatively, I could add an option on initialize to support, but I don't want to complicate the code and I think that with a proper version upgrade and maybe notification of some kind this would is a better default because the bits on disk are stored in the same way and we don't have to call reverse.

What do you think?

The use case I have is initializing a bloom filter from a Redis field value to update it in memory.

Thanks!