### PR TITLE
return enumerator if no block given; add #each_byte

### DIFF
--- a/lib/bitarray-array.rb
+++ b/lib/bitarray-array.rb
@@ -27,7 +27,7 @@ class BitArray
 
   # Iterate over each bit
   def each
-    return to_enum(:each) unless block_given?
+    return to_enum unless block_given?
     @size.times { |position| yield self[position] }
   end
 

--- a/lib/bitarray-array.rb
+++ b/lib/bitarray-array.rb
@@ -26,13 +26,20 @@ class BitArray
   end
 
   # Iterate over each bit
-  def each(&block)
+  def each
+    return to_enum(:each) unless block_given?
     @size.times { |position| yield self[position] }
   end
 
   # Returns the field as a string like "0101010100111100," etc.
   def to_s
     @field.collect{|ea| ("%0#{ELEMENT_WIDTH}b" % ea).reverse}.join[0..@size-1]
+  end
+  
+  # Iterate over each byte
+  def each_byte
+    return to_enum(:each_byte) unless block_given?
+    @field.each { |byte| yield byte }
   end
 
   # Returns the total number of bits that are set

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -49,7 +49,7 @@ class BitArray
   # Returns the total number of bits that are set
   # (The technique used here is about 6 times faster than using each or inject direct on the bitfield)
   def total_set
-    each_byte.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
+    @field.bytes.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
   end
 
   def byte_position(position)

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -26,7 +26,8 @@ class BitArray
   end
 
   # Iterate over each bit
-  def each(&block)
+  def each
+    return to_enum(:each) unless block_given?
     @size.times { |position| yield self[position] }
   end
 
@@ -38,11 +39,17 @@ class BitArray
       @field.bytes.collect { |ea| ("%08b" % ea) }.join[0, @size]
     end
   end
+  
+  # Iterates over each byte
+  def each_byte
+    return to_enum(:each_byte) unless block_given?
+    @field.bytes.each{ |byte| yield byte }
+  end
 
   # Returns the total number of bits that are set
   # (The technique used here is about 6 times faster than using each or inject direct on the bitfield)
   def total_set
-    @field.bytes.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
+    each_byte.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
   end
 
   def byte_position(position)


### PR DESCRIPTION
This just makes your `each` method work like other `Enumerable`s, and return an `Enumerator` if no block is given. Why is this important? The following code won't work without this change:
```Ruby
my_bit_array.each.with_index { |bit, index| puts "Bit at #{index}: #{bit}" }
```

Additionally, I added an `each_byte` method. This is useful if you want to iterate over each byte in the `BitArray`.

If you have any questions or comments, please let me know. Thanks!