### PR TITLE
Faster total set

### DIFF
--- a/lib/bitarray-array.rb
+++ b/lib/bitarray-array.rb
@@ -43,8 +43,9 @@ class BitArray
   end
 
   # Returns the total number of bits that are set
-  # (The technique used here is about 6 times faster than using each or inject direct on the bitfield)
+  # Use Brian Kernighan's way, see
+  # https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
   def total_set
-    @field.each_byte.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
+    @field.each_byte.inject(0) { |a, byte| (a += 1; byte &= byte - 1) while byte > 0 ; a }
   end
 end

--- a/lib/bitarray-array.rb
+++ b/lib/bitarray-array.rb
@@ -45,6 +45,6 @@ class BitArray
   # Returns the total number of bits that are set
   # (The technique used here is about 6 times faster than using each or inject direct on the bitfield)
   def total_set
-    @field.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
+    @field.each_byte.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
   end
 end

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -49,7 +49,7 @@ class BitArray
   # Returns the total number of bits that are set
   # (The technique used here is about 6 times faster than using each or inject direct on the bitfield)
   def total_set
-    @field.bytes.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
+    @field.each_byte.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
   end
 
   def byte_position(position)

--- a/lib/bitarray.rb
+++ b/lib/bitarray.rb
@@ -47,9 +47,10 @@ class BitArray
   end
 
   # Returns the total number of bits that are set
-  # (The technique used here is about 6 times faster than using each or inject direct on the bitfield)
+  # Use Brian Kernighan's way, see
+  # https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
   def total_set
-    @field.each_byte.inject(0) { |a, byte| a += byte & 1 and byte >>= 1 until byte == 0; a }
+    @field.each_byte.inject(0) { |a, byte| (a += 1; byte &= byte - 1) while byte > 0 ; a }
   end
 
   def byte_position(position)

--- a/test/test_bitarray.rb
+++ b/test/test_bitarray.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "bitarray"
+require_relative "../lib/bitarray"
 
 class TestBitArray < Minitest::Test
   def setup


### PR DESCRIPTION
## Description

Tweaks `total_set` to run faster. See the file changes for a more detailed description.

## Tests

The unit tests already had a (small) test for `total_set`; this still passes.
Additionally, I have tested it myself with a bitarray storing a bloom filter. The bitarray had 2,016,000,000 bits, of which 980,962,748 bits were set. The old code and the new code calculate the same value.